### PR TITLE
Ensure all bytes are written to TcpStream

### DIFF
--- a/src/virtual_iface/tcp.rs
+++ b/src/virtual_iface/tcp.rs
@@ -164,6 +164,7 @@ impl VirtualInterfacePoll for TcpVirtualInterface {
                         if client_socket.can_recv() {
                             match client_socket.recv(|buffer| (buffer.len(), buffer.to_vec())) {
                                 Ok(data) => {
+                                    debug!("[{}] Received {} bytes from virtual server", virtual_port, data.len());
                                     if !data.is_empty() {
                                         endpoint.send(Event::RemoteData(*virtual_port, data));
                                     }


### PR DESCRIPTION
Fixes #22. Turns out, `TcpStream#write` will sometimes truncate, especially on lower MTU's like ethernet.