### PR TITLE
Add host address binding option

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,7 @@ pub struct Config {
     pub(crate) private_key: Arc<X25519SecretKey>,
     pub(crate) endpoint_public_key: Arc<X25519PublicKey>,
     pub(crate) endpoint_addr: SocketAddr,
+    pub(crate) host_addr: Option<SocketAddr>,
     pub(crate) source_peer_ip: IpAddr,
     pub(crate) keepalive_seconds: Option<u16>,
     pub(crate) max_transmission_unit: usize,
@@ -76,6 +77,12 @@ impl Config {
                     .long("endpoint-addr")
                     .env("ONETUN_ENDPOINT_ADDR")
                     .help("The address (IP + port) of the WireGuard endpoint (remote). Example: 1.2.3.4:51820"),
+                Arg::with_name("host-addr")
+                    .required(false)
+                    .takes_value(true)
+                    .long("host-addr")
+                    .env("ONETUN_HOST_ADDR")
+                    .help("The address (IP + port) for the tunnel to bind to. Example: 1.2.4:51820"),
                 Arg::with_name("source-peer-ip")
                     .required(true)
                     .takes_value(true)
@@ -237,6 +244,12 @@ impl Config {
             ),
             endpoint_addr: parse_addr(matches.value_of("endpoint-addr"))
                 .with_context(|| "Invalid endpoint address")?,
+            host_addr: match matches.value_of("host-addr") {
+                Some(host_addr) => {
+                    Some(parse_addr(Some(host_addr)).with_context(|| "Invalid host address")?)
+                }
+                None => None,
+            },
             source_peer_ip,
             keepalive_seconds: parse_keep_alive(matches.value_of("keep-alive"))
                 .with_context(|| "Invalid keep-alive value")?,

--- a/src/config.rs
+++ b/src/config.rs
@@ -238,8 +238,8 @@ impl Config {
         let endpoint_bind_addr = if let Some(addr) = matches.value_of("endpoint-bind-addr") {
             let addr = parse_addr(Some(addr)).with_context(|| "Invalid host address")?;
             // Make sure the host address and endpoint address are the same IP version
-            if addr.ip().is_ipv6() && endpoint_addr.ip().is_ipv6()
-                || (addr.ip().is_ipv4() && endpoint_addr.ip().is_ipv4())
+            if addr.ip().is_ipv6() != endpoint_addr.ip().is_ipv6()
+                || (addr.ip().is_ipv4() != endpoint_addr.ip().is_ipv4())
             {
                 return Err(anyhow::anyhow!(
                     "Host address and endpoint address must be the same IP version"

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,7 +19,7 @@ pub struct Config {
     pub(crate) private_key: Arc<X25519SecretKey>,
     pub(crate) endpoint_public_key: Arc<X25519PublicKey>,
     pub(crate) endpoint_addr: SocketAddr,
-    pub(crate) host_addr: SocketAddr,
+    pub(crate) endpoint_bind_addr: SocketAddr,
     pub(crate) source_peer_ip: IpAddr,
     pub(crate) keepalive_seconds: Option<u16>,
     pub(crate) max_transmission_unit: usize,
@@ -77,11 +77,11 @@ impl Config {
                     .long("endpoint-addr")
                     .env("ONETUN_ENDPOINT_ADDR")
                     .help("The address (IP + port) of the WireGuard endpoint (remote). Example: 1.2.3.4:51820"),
-                Arg::with_name("host-addr")
+                Arg::with_name("endpoint-bind-addr")
                     .required(false)
                     .takes_value(true)
-                    .long("host-addr")
-                    .env("ONETUN_HOST_ADDR")
+                    .long("endpoint-bind-addr")
+                    .env("ONETUN_ENDPOINT_BIND_ADDR")
                     .help("The address (IP + port) used to bind the local UDP socket for the WireGuard tunnel. Example: 1.2.3.4:30000. Defaults to 0.0.0.0:0 for IPv4 endpoints, or [::]:0 for IPv6 endpoints."),
                 Arg::with_name("source-peer-ip")
                     .required(true)
@@ -235,7 +235,7 @@ impl Config {
         let endpoint_addr = parse_addr(matches.value_of("endpoint-addr"))
             .with_context(|| "Invalid endpoint address")?;
 
-        let host_addr = if let Some(addr) = matches.value_of("host-addr") {
+        let endpoint_bind_addr = if let Some(addr) = matches.value_of("endpoint-bind-addr") {
             let addr = parse_addr(Some(addr)).with_context(|| "Invalid host address")?;
             // Make sure the host address and endpoint address are the same IP version
             if addr.ip().is_ipv6() && endpoint_addr.ip().is_ipv6()
@@ -265,7 +265,7 @@ impl Config {
                     .with_context(|| "Invalid endpoint public key")?,
             ),
             endpoint_addr,
-            host_addr,
+            endpoint_bind_addr,
             source_peer_ip,
             keepalive_seconds: parse_keep_alive(matches.value_of("keep-alive"))
                 .with_context(|| "Invalid keep-alive value")?,

--- a/src/config.rs
+++ b/src/config.rs
@@ -82,7 +82,7 @@ impl Config {
                     .takes_value(true)
                     .long("host-addr")
                     .env("ONETUN_HOST_ADDR")
-                    .help("The address (IP + port) for the tunnel to bind to. Example: 1.2.4:51820"),
+                    .help("The address (IP + port) used to bind the local UDP socket for the WireGuard tunnel. Example: 1.2.3.4:30000. Defaults to 0.0.0.0:0 for IPv4 endpoints, or [::]:0 for IPv6 endpoints."),
                 Arg::with_name("source-peer-ip")
                     .required(true)
                     .takes_value(true)

--- a/src/config.rs
+++ b/src/config.rs
@@ -238,9 +238,7 @@ impl Config {
         let endpoint_bind_addr = if let Some(addr) = matches.value_of("endpoint-bind-addr") {
             let addr = parse_addr(Some(addr)).with_context(|| "Invalid host address")?;
             // Make sure the host address and endpoint address are the same IP version
-            if addr.ip().is_ipv6() != endpoint_addr.ip().is_ipv6()
-                || (addr.ip().is_ipv4() != endpoint_addr.ip().is_ipv4())
-            {
+            if addr.ip().is_ipv4() != endpoint_addr.ip().is_ipv4() {
                 return Err(anyhow::anyhow!(
                     "Endpoint and bind addresses must be the same IP version"
                 ));

--- a/src/config.rs
+++ b/src/config.rs
@@ -236,8 +236,8 @@ impl Config {
             .with_context(|| "Invalid endpoint address")?;
 
         let endpoint_bind_addr = if let Some(addr) = matches.value_of("endpoint-bind-addr") {
-            let addr = parse_addr(Some(addr)).with_context(|| "Invalid host address")?;
-            // Make sure the host address and endpoint address are the same IP version
+            let addr = parse_addr(Some(addr)).with_context(|| "Invalid bind address")?;
+            // Make sure the bind address and endpoint address are the same IP version
             if addr.ip().is_ipv4() != endpoint_addr.ip().is_ipv4() {
                 return Err(anyhow::anyhow!(
                     "Endpoint and bind addresses must be the same IP version"

--- a/src/config.rs
+++ b/src/config.rs
@@ -242,7 +242,7 @@ impl Config {
                 || (addr.ip().is_ipv4() != endpoint_addr.ip().is_ipv4())
             {
                 return Err(anyhow::anyhow!(
-                    "Host address and endpoint address must be the same IP version"
+                    "Endpoint and bind addresses must be the same IP version"
                 ));
             }
             addr

--- a/src/wg.rs
+++ b/src/wg.rs
@@ -36,16 +36,9 @@ impl WireGuardTunnel {
         let source_peer_ip = config.source_peer_ip;
         let peer = Self::create_tunnel(config)?;
         let endpoint = config.endpoint_addr;
-        let udp = if let Some(host) = config.host_addr {
-            UdpSocket::bind(host).await
-        } else {
-            UdpSocket::bind(match endpoint {
-                SocketAddr::V4(_) => "0.0.0.0:0",
-                SocketAddr::V6(_) => "[::]:0",
-            })
+        let udp = UdpSocket::bind(config.host_addr)
             .await
-        }
-        .with_context(|| "Failed to create UDP socket for WireGuard connection")?;
+            .with_context(|| "Failed to create UDP socket for WireGuard connection")?;
 
         Ok(Self {
             source_peer_ip,

--- a/src/wg.rs
+++ b/src/wg.rs
@@ -36,11 +36,15 @@ impl WireGuardTunnel {
         let source_peer_ip = config.source_peer_ip;
         let peer = Self::create_tunnel(config)?;
         let endpoint = config.endpoint_addr;
-        let udp = UdpSocket::bind(match endpoint {
-            SocketAddr::V4(_) => "0.0.0.0:0",
-            SocketAddr::V6(_) => "[::]:0",
-        })
-        .await
+        let udp = if let Some(host) = config.host_addr {
+            UdpSocket::bind(host).await
+        } else {
+            UdpSocket::bind(match endpoint {
+                SocketAddr::V4(_) => "0.0.0.0:0",
+                SocketAddr::V6(_) => "[::]:0",
+            })
+            .await
+        }
         .with_context(|| "Failed to create UDP socket for WireGuard connection")?;
 
         Ok(Self {

--- a/src/wg.rs
+++ b/src/wg.rs
@@ -36,7 +36,7 @@ impl WireGuardTunnel {
         let source_peer_ip = config.source_peer_ip;
         let peer = Self::create_tunnel(config)?;
         let endpoint = config.endpoint_addr;
-        let udp = UdpSocket::bind(config.host_addr)
+        let udp = UdpSocket::bind(config.endpoint_bind_addr)
             .await
             .with_context(|| "Failed to create UDP socket for WireGuard connection")?;
 


### PR DESCRIPTION
This PR allows for the user to define the socket address that onetun should bind to. This allows for systems where the outgoing address on the other end is not modifiable (such is the case on the iOS and Android client).