### PR TITLE
HTTP Proxy Server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,6 +147,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "futures"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,12 +274,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "http"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "496ce29bb5a52785b44e0f7ca2847ae0bb839c9bd28f69acac9b99d461c0c04c"
+
+[[package]]
+name = "httpdate"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
 name = "humantime"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 dependencies = [
  "quick-error",
+]
+
+[[package]]
+name = "hyper"
+version = "0.14.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42dc3c131584288d375f2d07f822b0cb012d8c6fb899a5b9fdb3cb7eb9b6004f"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
 ]
 
 [[package]]
@@ -307,6 +370,12 @@ name = "ip_network_table-deps-treebitmap"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e537132deb99c0eb4b752f0346b6a836200eaaa3516dd7e5514b63930a09e5d"
+
+[[package]]
+name = "itoa"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
 name = "jni"
@@ -433,6 +502,7 @@ dependencies = [
  "boringtun",
  "clap",
  "futures",
+ "hyper",
  "log",
  "nom",
  "pretty_env_logger",
@@ -738,6 +808,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+
+[[package]]
 name = "tracing"
 version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -768,6 +844,12 @@ checksum = "7b7358be39f2f274f322d2aaed611acc57f382e8eb1e5b48cb9ae30933495ce7"
 dependencies = [
  "once_cell",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "unicode-ident"
@@ -802,6 +884,16 @@ dependencies = [
  "same-file",
  "winapi",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+dependencies = [
+ "log",
+ "try-lock",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ nom = "7"
 async-trait = "0.1.51"
 priority-queue = "1.2.0"
 smoltcp = { version = "0.8.0", default-features = false, features = ["std", "log", "medium-ip", "proto-ipv4", "proto-ipv6", "socket-udp", "socket-tcp"] }
+hyper = { version = "0.14", features = ["server", "http1", "tcp"] }
 
 # bin-only dependencies
 clap = { version = "2.33", default-features = false, features = ["suggestions"], optional = true }

--- a/src/tunnel/http_proxy.rs
+++ b/src/tunnel/http_proxy.rs
@@ -1,0 +1,75 @@
+use std::convert::Infallible;
+use std::net::SocketAddr;
+use crate::{PortProtocol, TcpPortPool};
+use crate::Bus;
+
+use hyper::service::{make_service_fn, service_fn};
+use hyper::{Server, Method, Request, Body, Response, http};
+use hyper::server::conn::AddrStream;
+use crate::config::PortForwardConfig;
+use crate::tunnel::tcp::handle_tcp_proxy_connection;
+
+pub async fn http_proxy_server(
+    listen_addr: SocketAddr,
+    port_pool: TcpPortPool,
+    bus: Bus,
+) -> anyhow::Result<()> {
+
+    let make_service = make_service_fn(move |conn: &AddrStream| {
+        let bus = bus.clone();
+        let port_pool = port_pool.clone();
+        let addr = conn.remote_addr();
+        async move {
+            let addr = addr.clone();
+            Ok::<_, Infallible>(service_fn(move |req| proxy(addr, req, port_pool.clone(), bus.clone())))
+        }
+    });
+
+    let server = Server::bind(&listen_addr).serve(make_service);
+
+    Ok(server.await?)
+
+}
+
+async fn proxy(remote_addr: SocketAddr, req: Request<Body>, port_pool: TcpPortPool, bus: Bus) -> Result<Response<Body>, hyper::Error> {
+    debug!("http request from {}: {:?}", remote_addr, req);
+
+    if Method::CONNECT == req.method() {
+        if let Some(addr) = host_addr(req.uri()) {
+            tokio::task::spawn(async move {
+                match hyper::upgrade::on(req).await {
+                    Ok(upgraded) => {
+                        let config = PortForwardConfig {
+                            destination: addr.parse().expect("failed to parse destination SocketAddr"),
+                            source: remote_addr, // doesn't matter, won't be used
+                            protocol: PortProtocol::Tcp,
+                            remote: false
+                        };
+                        info!("proxy {} -> {}", remote_addr, config.destination);
+                        if let Err(e) = handle_tcp_proxy_connection(upgraded, port_pool.next().await.unwrap(), config, bus.clone()).await {
+                            eprintln!("server io error: {}", e);
+                        };
+                    }
+                    Err(e) => eprintln!("upgrade error: {}", e),
+                }
+            });
+
+            Ok(Response::new(Body::empty()))
+        } else {
+            eprintln!("CONNECT host is not socket addr: {:?}", req.uri());
+            let mut resp = Response::new(Body::from("CONNECT must be to a socket address"));
+            *resp.status_mut() = http::StatusCode::BAD_REQUEST;
+
+            Ok(resp)
+        }
+    } else {
+        let mut resp = Response::new(Body::from("Only CONNECT method supported"));
+        *resp.status_mut() = http::StatusCode::METHOD_NOT_ALLOWED;
+
+        Ok(resp)
+    }
+}
+
+fn host_addr(uri: &http::Uri) -> Option<String> {
+    uri.authority().and_then(|auth| Some(auth.to_string()))
+}


### PR DESCRIPTION
Adds an option to create an HTTP proxy server which forwards all requests through the WireGuard tunnel. `onetun [...] --http-proxy 127.0.0.1:8080` and then `socat - PROXY:127.0.0.1:1.1.1.1:80,proxyport=8080` or `curl http://1.1.1.1 -x http://127.0.0.1:8080 -p -v`.

Currently, the proxy only supports IP addresses, although it would be possible to add DNS resolution. It also only supports the CONNECT method, but it would be possible to add support for other methods.

The use case for this feature is that you can connect to any IP address you want after starting onetun--you don't have to launch new onetun instances or know all the destination IP addresses upfront.