### PR TITLE
Use bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,6 +437,7 @@ dependencies = [
  "async-recursion",
  "async-trait",
  "boringtun",
+ "bytes",
  "clap",
  "futures",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ priority-queue = "1.2.0"
 smoltcp = { version = "0.8.0", default-features = false, features = ["std", "log", "medium-ip", "proto-ipv4", "proto-ipv6", "socket-udp", "socket-tcp"] }
 # forward boringtuns tracing events to log
 tracing = { version = "0.1.36", default-features = false, features = ["log"] }
+bytes = "1"
 
 # bin-only dependencies
 clap = { version = "2.33", default-features = false, features = ["suggestions"], optional = true }

--- a/src/config.rs
+++ b/src/config.rs
@@ -329,7 +329,7 @@ fn is_file_insecurely_readable(path: &str) -> Option<(bool, bool)> {
     use std::fs::File;
     use std::os::unix::fs::MetadataExt;
 
-    let mode = File::open(&path).ok()?.metadata().ok()?.mode();
+    let mode = File::open(path).ok()?.metadata().ok()?.mode();
     Some((mode & 0o40 > 0, mode & 0o4 > 0))
 }
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,3 +1,4 @@
+use bytes::Bytes;
 use std::fmt::{Display, Formatter};
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
@@ -16,13 +17,13 @@ pub enum Event {
     /// A connection was dropped from the pool and should be closed in all interfaces.
     ClientConnectionDropped(VirtualPort),
     /// Data received by the local server that should be sent to the virtual server.
-    LocalData(PortForwardConfig, VirtualPort, Vec<u8>),
+    LocalData(PortForwardConfig, VirtualPort, Bytes),
     /// Data received by the remote server that should be sent to the local client.
-    RemoteData(VirtualPort, Vec<u8>),
+    RemoteData(VirtualPort, Bytes),
     /// IP packet received from the WireGuard tunnel that should be passed through the corresponding virtual device.
-    InboundInternetPacket(PortProtocol, Vec<u8>),
+    InboundInternetPacket(PortProtocol, Bytes),
     /// IP packet to be sent through the WireGuard tunnel as crafted by the virtual device.
-    OutboundInternetPacket(Vec<u8>),
+    OutboundInternetPacket(Bytes),
     /// Notifies that a virtual device read an IP packet.
     VirtualDeviceFed(PortProtocol),
 }

--- a/src/tunnel/udp.rs
+++ b/src/tunnel/udp.rs
@@ -4,14 +4,15 @@ use std::ops::Range;
 use std::sync::Arc;
 use std::time::Instant;
 
-use crate::events::{Bus, Event};
 use anyhow::Context;
+use bytes::Bytes;
 use priority_queue::double_priority_queue::DoublePriorityQueue;
 use rand::seq::SliceRandom;
 use rand::thread_rng;
 use tokio::net::UdpSocket;
 
 use crate::config::{PortForwardConfig, PortProtocol};
+use crate::events::{Bus, Event};
 use crate::virtual_iface::VirtualPort;
 
 const MAX_PACKET: usize = 65536;
@@ -98,7 +99,7 @@ async fn next_udp_datagram(
     socket: &UdpSocket,
     buffer: &mut [u8],
     port_pool: UdpPortPool,
-) -> anyhow::Result<Option<(VirtualPort, Vec<u8>)>> {
+) -> anyhow::Result<Option<(VirtualPort, Bytes)>> {
     let (size, peer_addr) = socket
         .recv_from(buffer)
         .await
@@ -126,7 +127,7 @@ async fn next_udp_datagram(
     port_pool.update_last_transmit(port).await;
 
     let data = buffer[..size].to_vec();
-    Ok(Some((port, data)))
+    Ok(Some((port, data.into())))
 }
 
 /// A pool of virtual ports available for TCP connections.

--- a/src/wg.rs
+++ b/src/wg.rs
@@ -209,7 +209,7 @@ impl WireGuardTunnel {
                     trace_ip_packet("Received IP packet", packet);
 
                     if let Some(proto) = self.route_protocol(packet) {
-                        endpoint.send(Event::InboundInternetPacket(proto, packet.into()));
+                        endpoint.send(Event::InboundInternetPacket(proto, packet.to_vec().into()));
                     }
                 }
                 _ => {}


### PR DESCRIPTION
Improves memory footprint of `onetun` when serving concurrent connections