### PR TITLE
Support pre-shared key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -445,6 +445,7 @@ dependencies = [
  "anyhow",
  "async-recursion",
  "async-trait",
+ "base64",
  "boringtun",
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ async-trait = "0.1"
 priority-queue = "1.3.0"
 smoltcp = { version = "0.8.2", default-features = false, features = ["std", "log", "medium-ip", "proto-ipv4", "proto-ipv6", "socket-udp", "socket-tcp"] }
 bytes = "1"
-base64 = "0.21"
+base64 = "0.13"
 
 # forward boringtuns tracing events to log
 tracing = { version = "0.1", default-features = false, features = ["log"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ async-trait = "0.1"
 priority-queue = "1.3.0"
 smoltcp = { version = "0.8.2", default-features = false, features = ["std", "log", "medium-ip", "proto-ipv4", "proto-ipv6", "socket-udp", "socket-tcp"] }
 bytes = "1"
+base64 = "0.21"
 
 # forward boringtuns tracing events to log
 tracing = { version = "0.1", default-features = false, features = ["log"] }

--- a/README.md
+++ b/README.md
@@ -188,6 +188,13 @@ You can bind to a static address instead using `--endpoint-bind-addr`:
 onetun --endpoint-bind-addr 0.0.0.0:51820 --endpoint-addr 140.30.3.182:51820 [...]
 ```
 
+The security of the WireGuard connection can be further enhanced with a **pre-shared key** (PSK). You can generate such a key with the `wg genpsk` command, and provide it using `--preshared-key`.
+The peer must also have this key configured using the `PresharedKey` option.
+
+```shell
+onetun --preshared-key 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX' [...]
+```
+
 ## Architecture
 
 **In short:** onetun uses [smoltcp's](https://github.com/smoltcp-rs/smoltcp) TCP/IP and UDP stack to generate IP packets

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,7 +6,6 @@ use std::net::{IpAddr, SocketAddr, ToSocketAddrs};
 use std::sync::Arc;
 
 use anyhow::Context;
-use base64::prelude::{Engine as _, BASE64_STANDARD};
 pub use boringtun::crypto::{X25519PublicKey, X25519SecretKey};
 
 const DEFAULT_PORT_FORWARD_SOURCE: &str = "127.0.0.1";
@@ -317,9 +316,7 @@ fn parse_public_key(s: Option<&str>) -> anyhow::Result<X25519PublicKey> {
 
 fn parse_preshared_key(s: Option<&str>) -> anyhow::Result<Option<[u8; 32]>> {
     if let Some(s) = s {
-        let psk = BASE64_STANDARD
-            .decode(s)
-            .with_context(|| "Invalid pre-shared key")?;
+        let psk = base64::decode(s).with_context(|| "Invalid pre-shared key")?;
         Ok(Some(psk.try_into().map_err(|_| {
             anyhow::anyhow!("Unsupported pre-shared key")
         })?))

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,7 +17,7 @@ pub struct Config {
     pub remote_port_forwards: Vec<PortForwardConfig>,
     pub private_key: Arc<X25519SecretKey>,
     pub endpoint_public_key: Arc<X25519PublicKey>,
-    pub endpoint_preshared_key: Option<[u8; 32]>,
+    pub preshared_key: Option<[u8; 32]>,
     pub endpoint_addr: SocketAddr,
     pub endpoint_bind_addr: SocketAddr,
     pub source_peer_ip: IpAddr,
@@ -74,12 +74,12 @@ impl Config {
                     .long("endpoint-public-key")
                     .env("ONETUN_ENDPOINT_PUBLIC_KEY")
                     .help("The public key of the WireGuard endpoint (remote)."),
-                Arg::with_name("endpoint-preshared-key")
+                Arg::with_name("preshared-key")
                     .required(false)
                     .takes_value(true)
-                    .long("endpoint-preshared-key")
-                    .env("ONETUN_ENDPOINT_PRESHARED_KEY")
-                    .help("The pre-shared key of the WireGuard endpoint (remote)."),
+                    .long("preshared-key")
+                    .env("ONETUN_PRESHARED_KEY")
+                    .help("The pre-shared key (PSK) as configured with the peer."),
                 Arg::with_name("endpoint-addr")
                     .required(true)
                     .takes_value(true)
@@ -271,9 +271,7 @@ impl Config {
                 parse_public_key(matches.value_of("endpoint-public-key"))
                     .with_context(|| "Invalid endpoint public key")?,
             ),
-            endpoint_preshared_key: parse_preshared_key(
-                matches.value_of("endpoint-preshared-key"),
-            )?,
+            preshared_key: parse_preshared_key(matches.value_of("preshared-key"))?,
             endpoint_addr,
             endpoint_bind_addr,
             source_peer_ip,

--- a/src/wg.rs
+++ b/src/wg.rs
@@ -221,7 +221,7 @@ impl WireGuardTunnel {
         Tunn::new(
             config.private_key.clone(),
             config.endpoint_public_key.clone(),
-            None,
+            config.endpoint_preshared_key,
             config.keepalive_seconds,
             0,
             None,

--- a/src/wg.rs
+++ b/src/wg.rs
@@ -221,7 +221,7 @@ impl WireGuardTunnel {
         Tunn::new(
             config.private_key.clone(),
             config.endpoint_public_key.clone(),
-            config.endpoint_preshared_key,
+            config.preshared_key,
             config.keepalive_seconds,
             0,
             None,


### PR DESCRIPTION
Wireguard tunnels may be encrypted with an optional, pre-shared key. It adds an additional layer of symmetric-key  cryptography  for post-quantum resistance. This PR adds `--endpoint-preshared-key` /`ONETUN_ENDPOINT_PRESHARED_KEY` to specify such a key.