### PR TITLE
chore: update Dockerfile rust version 1.63.0 -> 1.65.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.63.0 as cargo-build
+FROM rust:1.65.0 as cargo-build
 
 WORKDIR /usr/src/onetun
 COPY Cargo.toml Cargo.toml


### PR DESCRIPTION
Docker build seems broken since v0.3.2.

I tried building and i got the error:

```
error: package `regex-automata v0.4.3` cannot be built because it requires rustc 1.65 or newer, while the currently active rustc version is 1.63.0
```

I just updated the rust version to 1.65.0 and now everything seems to works fine.