### PR TITLE
update MSRV to 1.65.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.63.0
+          - 1.65.0
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -39,7 +39,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.63.0
+          - 1.65.0
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.63.0 as cargo-build
+FROM rust:1.65.0 as cargo-build
 
 WORKDIR /usr/src/onetun
 COPY Cargo.toml Cargo.toml

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ For example,
 
 ## Download
 
-onetun is available to install from [crates.io](https://crates.io/crates/onetun) with Rust ≥1.63.0:
+onetun is available to install from [crates.io](https://crates.io/crates/onetun) with Rust ≥1.65.0:
 
 ```shell
 cargo install onetun
@@ -37,7 +37,7 @@ docker run --rm --name onetun --user 1000 -p 8080:8080 aramperes/onetun \
     0.0.0.0:8080:192.168.4.2:8080 [...options...]
 ```
 
-You can also build onetun locally, using Rust ≥1.63.0:
+You can also build onetun locally, using Rust ≥1.65.0:
 
 ```shell
 git clone https://github.com/aramperes/onetun && cd onetun

--- a/src/virtual_device.rs
+++ b/src/virtual_device.rs
@@ -119,8 +119,7 @@ impl smoltcp::phy::TxToken for TxToken {
     where
         F: FnOnce(&mut [u8]) -> smoltcp::Result<R>,
     {
-        let mut buffer = Vec::new();
-        buffer.resize(len, 0);
+        let mut buffer = vec![0; len];
         let result = f(&mut buffer);
         self.sender
             .send(Event::OutboundInternetPacket(buffer.into()));

--- a/src/virtual_iface/tcp.rs
+++ b/src/virtual_iface/tcp.rs
@@ -229,7 +229,7 @@ impl VirtualInterfacePoll for TcpVirtualInterface {
                                 next_poll = None;
                             }
                         }
-                        Event::VirtualDeviceFed(protocol) if protocol == PortProtocol::Tcp => {
+                        Event::VirtualDeviceFed(PortProtocol::Tcp) => {
                             next_poll = None;
                         }
                         _ => {}

--- a/src/virtual_iface/udp.rs
+++ b/src/virtual_iface/udp.rs
@@ -198,7 +198,7 @@ impl VirtualInterfacePoll for UdpVirtualInterface {
                             }
                             next_poll = None;
                         }
-                        Event::VirtualDeviceFed(protocol) if protocol == PortProtocol::Udp => {
+                        Event::VirtualDeviceFed(PortProtocol::Udp) => {
                             next_poll = None;
                         }
                         _ => {}


### PR DESCRIPTION
Supersedes #56

Needed because `regex-automata` (indirect dependency) requires 1.65.0.