### PR TITLE
increase default smoltcp interface limit and add to README

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,4 @@
+[env]
+# Each interface needs 1 IP allocated to the WireGuard peer IP.
+# "8" = 7 tunnels per protocol.
+SMOLTCP_IFACE_MAX_ADDR_COUNT = "8"

--- a/README.md
+++ b/README.md
@@ -126,6 +126,14 @@ INFO  onetun::tunnel > Tunneling TCP [127.0.0.1:8081]->[192.168.4.4:8081] (via [
 
 ... would open TCP ports 8080 and 8081 locally, which forward to their respective ports on the different peers.
 
+#### Maximum number of tunnels
+
+`smoltcp` imposes a compile-time limit on the number of IP addresses assigned to an interface. **onetun** increases
+the default value to support most use-cases. In effect, the default limit on the number of **onetun** peers
+is **7 per protocol** (TCP and UDP).
+
+Should you need more unique IP addresses to forward ports to, you can increase the limit in `.cargo/config.toml` and recompile **onetun**.
+
 ### UDP Support
 
 **onetun** supports UDP forwarding. You can add `:UDP` at the end of the port-forward configuration, or `UDP,TCP` to support

--- a/src/virtual_device.rs
+++ b/src/virtual_device.rs
@@ -55,8 +55,14 @@ impl VirtualIpDevice {
 }
 
 impl smoltcp::phy::Device for VirtualIpDevice {
-    type RxToken<'a> = RxToken where Self: 'a;
-    type TxToken<'a> = TxToken where Self: 'a;
+    type RxToken<'a>
+        = RxToken
+    where
+        Self: 'a;
+    type TxToken<'a>
+        = TxToken
+    where
+        Self: 'a;
 
     fn receive(&mut self, _timestamp: Instant) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
         let next = {

--- a/src/virtual_iface/tcp.rs
+++ b/src/virtual_iface/tcp.rs
@@ -94,7 +94,9 @@ impl VirtualInterfacePoll for TcpVirtualInterface {
         let mut iface = Interface::new(config, &mut device, Instant::now());
         iface.update_ip_addrs(|ip_addrs| {
             addresses.into_iter().for_each(|addr| {
-                ip_addrs.push(addr).unwrap();
+                ip_addrs
+                    .push(addr)
+                    .expect("maximum number of IPs in TCP interface reached");
             });
         });
 

--- a/src/virtual_iface/udp.rs
+++ b/src/virtual_iface/udp.rs
@@ -106,7 +106,9 @@ impl VirtualInterfacePoll for UdpVirtualInterface {
         let mut iface = Interface::new(config, &mut device, Instant::now());
         iface.update_ip_addrs(|ip_addrs| {
             addresses.into_iter().for_each(|addr| {
-                ip_addrs.push(addr).unwrap();
+                ip_addrs
+                    .push(addr)
+                    .expect("maximum number of IPs in UDP interface reached");
             });
         });
 


### PR DESCRIPTION
ref: #63

`smoltcp v0.11` imposes a limit of 2 IP addresses per interface. This would restrict the **onetun** tunnel limit to 1 unique peer IP address (since 1 is reserved for the onetun's own IP).

An environment variable can be used at compile-time to increase this limit. I have increased onetun's default from 2 to 8.

Future investigation could be made to configure the `Interface` in a way that convers the entire WireGuard subnet (or even `0.0.0.0/0` as default), but that seems to break the tunnel functionality I have not had time to investigate.